### PR TITLE
@strapi/utils dep blocks from using node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "./lib",
   "dependencies": {
     "postmark": "^2.7.8",
-    "@strapi/utils": "4.0.0"
+    "@strapi/utils": "^4.0.0"
   },
   "strapi": {
     "isProvider": true


### PR DESCRIPTION
@strapi/utils is pinned to 4.0.0. This prevents me from using Node 18 (It has 14/16 in its engines block).

I guess there is no real need to pin it to 4.0.0 right?